### PR TITLE
Add support for additional metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ class AccountApproved extends Notification
             ->iOS()
             ->badge(1)
             ->sound('success')
+            ->meta(['foo' => 'bar'])
             ->body("Your {$notifiable->service} account was approved!");
     }
 }
@@ -99,6 +100,7 @@ class AccountApproved extends Notification
 - `title('')`: Accepts a string value for the title.
 - `body('')`: Accepts a string value for the body.
 - `sound('')`: Accepts a string value for the notification sound file. Notice that if you leave blank the default sound value will be `default`.
+- `meta([...])`: Accepts an array of custom data to be sent along with the push message. Works for both platforms. See more at [Pusher Beams - Adding metadata to a notification](https://pusher.com/docs/beams/guides/publishing-to-multiple-devices)
 - `icon('')`: Accepts a string value for the icon file. (Android Only)
 - `badge(1)`: Accepts an integer value for the badge. (iOS Only)
 - `setOption($key, $value)`: Allows you to set any value in the message payload. See the [request body section of the Pusher Beam docs](https://pusher.com/docs/beams/reference/publish-api#request-body) for more information.

--- a/src/PusherMessage.php
+++ b/src/PusherMessage.php
@@ -43,6 +43,13 @@ class PusherMessage
     protected array $options = [];
 
     /**
+     * Meta data that will be passed along with the message.
+     *
+     * @var array
+     */
+    protected array $meta = [];
+
+    /**
      * An extra message to the other platform.
      *
      * @var
@@ -248,6 +255,20 @@ class PusherMessage
     }
 
     /**
+     * Set the metadata.
+     *
+     * @param array $meta
+     *
+     * @return $this
+     */
+    public function meta(array $meta)
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    /**
      * Set the message link.
      *
      * @param  string  $value
@@ -306,6 +327,10 @@ class PusherMessage
             ],
         ];
 
+        if ($this->meta && count($this->meta)) {
+            $message['apns']['data'] = $this->meta;
+        }
+
         $this->formatMessage($message);
 
         return $message;
@@ -328,6 +353,10 @@ class PusherMessage
                 ]),
             ],
         ];
+
+        if ($this->meta && count($this->meta)) {
+            $message['fcm']['data'] = $this->meta;
+        }
 
         $this->formatMessage($message);
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -124,4 +124,22 @@ class MessageTest extends MockeryTestCase
         $this->assertTrue(Arr::has($this->message->toArray(), 'apns'));
         $this->assertTrue(Arr::has($this->message->toArray(), 'fcm'));
     }
+
+    /** @test */
+    public function it_has_no_meta_by_default()
+    {
+        $this->message;
+        $this->assertFalse(Arr::has($this->message->toArray(), 'apns.data'));
+        $this->assertFalse(Arr::has($this->message->toArray(), 'apns.data'));
+    }
+
+    /** @test */
+    public function it_can_add_meta()
+    {
+        $this->message->meta(['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], Arr::get($this->message->toArray(), 'apns.data'));
+
+        $this->message->android();
+        $this->assertEquals(['foo' => 'bar'], Arr::get($this->message->toArray(), 'fcm.data'));
+    }
 }


### PR DESCRIPTION
- Update Pusher Beams message to pass meta data along with [message parameters](https://pusher.com/docs/beams/guides/publishing-to-multiple-devices#adding-metadata-to-a-notification)
- Merged from Pending [PR #65](https://github.com/laravel-notification-channels/pusher-push-notifications/pull/65)