### PR TITLE
Return send response from pusher gateway

### DIFF
--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -25,9 +25,9 @@ class PusherChannel
      *
      * @param  mixed  $notifiable
      * @param  Notification  $notification
-     * @return void
+     * @return mixed
      */
-    public function send($notifiable, Notification $notification): void
+    public function send($notifiable, Notification $notification): mixed
     {
         $type = $notifiable->pushNotificationType ?? self::INTERESTS;
 
@@ -37,7 +37,7 @@ class PusherChannel
         try {
             $notificationType = sprintf('publishTo%s', Str::ucfirst($type));
 
-            $this->beamsClient->{$notificationType}(
+            return $this->beamsClient->{$notificationType}(
                 Arr::wrap($data),
                 $notification->toPushNotification($notifiable)->toArray()
             );


### PR DESCRIPTION
This PR makes a minor change which returns the response from the pusher gateway back to the laravel notification system so that the `publishId` returned from the gateway can be tracked and used.

When sending a new pusher notification, the response returns a [`publishId`](https://pusher.com/docs/beams/reference/publish-api/#response-body) to denote that the pusher gateway accepted it for delivery.  This `publishId` is then used in various [webhooks](https://pusher.com/docs/beams/concepts/webhooks/) you can setup on the pusher gateway to check the delivery status of the notification through to Apple and Google's push gateways.

Currently, this `publishId` response is discarded in the current code, so you cannot effectively use this library with Pusher web hooks.  This minor fix updates the send code to return the pusher gateway response, so it can be picked up in laravel's `Illuminate\Notifications\Events\NotificationSent` response and saved to your database along with the notification or used otherwise.