### PR TITLE
Add tests for send responses (#6)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -45,6 +45,7 @@ class PusherChannel
             $this->events->dispatch(
                 new NotificationFailed($notifiable, $notification, 'pusher-push-notifications', ['exception' => $exception])
             );
+            return null;
         }
     }
 

--- a/src/PusherChannel.php
+++ b/src/PusherChannel.php
@@ -25,9 +25,9 @@ class PusherChannel
      *
      * @param  mixed  $notifiable
      * @param  Notification  $notification
-     * @return void
+     * @return mixed
      */
-    public function send($notifiable, Notification $notification): void
+    public function send($notifiable, Notification $notification): mixed
     {
         $type = $notifiable->pushNotificationType ?? self::INTERESTS;
 
@@ -37,7 +37,7 @@ class PusherChannel
         try {
             $notificationType = sprintf('publishTo%s', Str::ucfirst($type));
 
-            $this->beamsClient->{$notificationType}(
+            return $this->beamsClient->{$notificationType}(
                 Arr::wrap($data),
                 $notification->toPushNotification($notifiable)->toArray()
             );

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -15,8 +15,19 @@ use Pusher\PushNotifications\PushNotifications;
 
 class ChannelTest extends MockeryTestCase
 {
+    private $pusher;
+    private $events;
+    private $channel;
+    private $notification;
+    private $notifiableInterest;
+    private $notifiableInterests;
+    private $notifiableUser;
+    private $notifiableUsers;
+    
     public function setUp(): void
     {
+        parent::setUp();
+
         $this->pusher = Mockery::mock(PushNotifications::class);
 
         $this->events = Mockery::mock(Dispatcher::class);
@@ -39,9 +50,11 @@ class ChannelTest extends MockeryTestCase
 
         $data = $message->toArray();
 
-        $this->pusher->shouldReceive('publishToInterests')->once()->with(['interest_name'], $data);
+        $this->pusher->shouldReceive('publishToInterests')->once()->with(['interest_name'], $data)->andReturn(['publishId' => 'some-id']);
 
-        $this->channel->send($this->notifiableInterest, $this->notification);
+        $response = $this->channel->send($this->notifiableInterest, $this->notification);
+
+        $this->assertArrayHasKey('publishId', $response);
     }
 
     /** @test */
@@ -53,9 +66,11 @@ class ChannelTest extends MockeryTestCase
 
         $this->pusher->shouldReceive('publishToInterests')->once()->with([
             'interest_one', 'interest_two', 'interest_three',
-        ], $data);
+        ], $data)->andReturn(['publishId' => 'some-id']);
 
-        $this->channel->send($this->notifiableInterests, $this->notification);
+        $response = $this->channel->send($this->notifiableInterests, $this->notification);
+
+        $this->assertArrayHasKey('publishId', $response);
     }
 
     /** @test */
@@ -79,9 +94,11 @@ class ChannelTest extends MockeryTestCase
 
         $data = $message->toArray();
 
-        $this->pusher->shouldReceive('publishToUsers')->once()->with(['user_1'], $data);
+        $this->pusher->shouldReceive('publishToUsers')->once()->with(['user_1'], $data)->andReturn(['publishId' => 'some-id']);
 
-        $this->channel->send($this->notifiableUser, $this->notification);
+        $response = $this->channel->send($this->notifiableUser, $this->notification);
+
+        $this->assertArrayHasKey('publishId', $response);
     }
 
     /** @test */
@@ -93,9 +110,11 @@ class ChannelTest extends MockeryTestCase
 
         $this->pusher->shouldReceive('publishToUsers')->once()->with([
             'user_1', 'user_2', 'user_3',
-        ], $data);
+        ], $data)->andReturn(['publishId' => 'some-id']);
 
-        $this->channel->send($this->notifiableUsers, $this->notification);
+        $response = $this->channel->send($this->notifiableUsers, $this->notification);
+
+        $this->assertArrayHasKey('publishId', $response);
     }
 
     /** @test */


### PR DESCRIPTION
- Upgrade phpunit.xml to latest spec
- Update tests to capture and check response
- Make sure value returned for each coverage case in pusherchannel->send()
- Fix deprecated use of non-class members in ChannelTest